### PR TITLE
feat: add support for lsqpack_enc_decoder_in from Encoder

### DIFF
--- a/ls-qpack/src/encoder.rs
+++ b/ls-qpack/src/encoder.rs
@@ -144,6 +144,14 @@ impl Encoder {
         EncodingBlock::new(self, stream_id, seqno)
     }
 
+    /// Feeds data from decoder's buffer stream.
+    pub fn feed<D>(&mut self, data: D) -> Result<(), EncoderError>
+        where
+            D: AsRef<[u8]>,
+    {
+        self.inner.as_mut().feed_decoder_data(data.as_ref())
+    }
+
     /// Return estimated compression ratio until this point.
     ///
     /// Compression ratio is defined as size of the output divided by the size of the
@@ -418,6 +426,20 @@ impl InnerEncoder {
             hdr_block.extend_from_slice(&this.hdr_buffer);
 
             Ok((hdr_block, std::mem::take(&mut this.enc_buffer)))
+        } else {
+            Err(EncoderError)
+        }
+    }
+
+    fn feed_decoder_data(self: Pin<&Self>, data: &[u8]) -> Result<(), EncoderError> {
+        let this = unsafe { self.get_unchecked_mut() };
+
+        let result = unsafe {
+            ls_qpack_sys::lsqpack_enc_decoder_in(&mut this.encoder, data.as_ptr(), data.len())
+        };
+
+        if result == 0 {
+            Ok(())
         } else {
             Err(EncoderError)
         }


### PR DESCRIPTION
Hello,

I am submitting this PR to add support for "lsqpack_enc_decoder_in" function.
From ls-qpack upstream docs we can read about its purpose "Process next chunk of bytes from the decoder stream".

See https://github.com/litespeedtech/ls-qpack/blob/521792711f2839f05565fd3dd617708cfb5b80ee/lsqpack.h#L288

There's another thing I'd like to see, but I don't see how we can without breaking the compatibility. I am fairly new to Rust, so I am requesting your advises on this one:

In `decoder.rs`, looking at the `lsqpack_dec_header_in` function wrap/bridge, I can see that you don't want to retrieve the "control"/"stream" data by passing the two last argument to respectively NULL and 0.
How can we still retrieve this? Because I need it. This part return (on the Ok path) a Vec of Header, while it should normally do the same as the encoder by returning a DecoderResult wrapping the stream/control data along with the Vec of Header, Am I wrong?

```rust
let result = unsafe {
    ls_qpack_sys::lsqpack_dec_header_in(
        &mut this.decoder,
        hblock_ctx.as_mut().as_mut_ptr() as *mut libc::c_void,
        stream_id.value(),
        header_block_len,
        &mut cursor_after,
        encoded_cursor_len,
        std::ptr::null_mut(),  // normally for dec/stream ctrl data, here ignored.
        &mut 0,
    )
};
```

Regards,