### PR TITLE
feat: Further implement ls-qpack, especially around stream data in/out

### DIFF
--- a/ls-qpack/src/decoder.rs
+++ b/ls-qpack/src/decoder.rs
@@ -224,7 +224,8 @@ impl InnerDecoder {
 
                 let hblock_ctx = unsafe { Pin::into_inner_unchecked(hblock_ctx) };
 
-                Ok(DecoderOutput::Done(BuffersDecoded { headers: hblock_ctx.decoded_headers(), stream: buffer.into()}))
+                buffer.truncate(sdtc_buffer_size);
+                Ok(DecoderOutput::Done(BuffersDecoded { headers: hblock_ctx.decoded_headers(), stream: buffer.into_boxed_slice()}))
             }
 
             ls_qpack_sys::lsqpack_read_header_status_LQRHS_BLOCKED => {

--- a/ls-qpack/src/decoder.rs
+++ b/ls-qpack/src/decoder.rs
@@ -75,7 +75,7 @@ pub enum DecoderOutput {
 impl DecoderOutput {
     /// If the result is unblocked, it will return `Some(Vec<header>)`.
     /// Otherwise `None`.
-    pub fn take(self) -> Option<Vec<Header>> {
+    pub fn take(self) -> Option<BuffersDecoded> {
         match self {
             Self::Done(v) => Some(v),
             Self::BlockedStream => None,
@@ -224,7 +224,7 @@ impl InnerDecoder {
 
                 let hblock_ctx = unsafe { Pin::into_inner_unchecked(hblock_ctx) };
 
-                Ok(DecoderOutput::Done(BuffersDecoded { headers: hblock_ctx.decoded_headers(), stream: buffer}))
+                Ok(DecoderOutput::Done(BuffersDecoded { headers: hblock_ctx.decoded_headers(), stream: buffer.into()}))
             }
 
             ls_qpack_sys::lsqpack_read_header_status_LQRHS_BLOCKED => {
@@ -282,7 +282,7 @@ impl InnerDecoder {
                 }
 
                 let hdbk = unsafe { Pin::into_inner_unchecked(hdbk) };
-                Some(Ok(DecoderOutput::Done(BuffersDecoded { headers: hdbk.decoded_headers(), stream: []})))
+                Some(Ok(DecoderOutput::Done(BuffersDecoded { headers: hdbk.decoded_headers(), stream: Box::new([])})))
             }
 
             hash_map::Entry::Vacant(_) => None,

--- a/ls-qpack/src/encoder.rs
+++ b/ls-qpack/src/encoder.rs
@@ -431,7 +431,7 @@ impl InnerEncoder {
         }
     }
 
-    fn feed_decoder_data(self: Pin<&Self>, data: &[u8]) -> Result<(), EncoderError> {
+    fn feed_decoder_data(self: Pin<&mut Self>, data: &[u8]) -> Result<(), EncoderError> {
         let this = unsafe { self.get_unchecked_mut() };
 
         let result = unsafe {

--- a/ls-qpack/src/encoder.rs
+++ b/ls-qpack/src/encoder.rs
@@ -144,6 +144,14 @@ impl Encoder {
         EncodingBlock::new(self, stream_id, seqno)
     }
 
+    /// Feeds data from decoder's buffer stream.
+    pub fn feed<D>(&mut self, data: D) -> Result<(), EncoderError>
+        where
+            D: AsRef<[u8]>,
+    {
+        self.inner.as_mut().feed_decoder_data(data.as_ref())
+    }
+
     /// Return estimated compression ratio until this point.
     ///
     /// Compression ratio is defined as size of the output divided by the size of the
@@ -418,6 +426,20 @@ impl InnerEncoder {
             hdr_block.extend_from_slice(&this.hdr_buffer);
 
             Ok((hdr_block, std::mem::take(&mut this.enc_buffer)))
+        } else {
+            Err(EncoderError)
+        }
+    }
+
+    fn feed_decoder_data(self: Pin<&Self>, data: &[u8]) -> Result<(), EncoderError> {
+        let this = unsafe { self.get_unchecked_mut() };
+
+        let result = unsafe {
+            ls_qpack_sys::lsqpack_enc_decoder_in(&mut this.encoder, data.as_ptr(), data.len())
+        };
+
+        if result == 0 {
+            Ok(())
         } else {
             Err(EncoderError)
         }

--- a/ls-qpack/src/header.rs
+++ b/ls-qpack/src/header.rs
@@ -15,6 +15,7 @@ pub enum HeaderError {
 /// QPACK Header.
 ///
 /// A `Header` essentially is a pair composed by two strings. That is, a name and a value.
+#[derive(Clone)]
 pub struct Header {
     buffer: Box<[u8]>,
     name_offset: usize,


### PR DESCRIPTION
Hello,

This PR supersede #11 
The story remain identical on the goals. The crate you started is really useful, and I would like to contribute
in order to make this further usable in various use cases.

- Retrieve stream data on all decoders methods
- Add feed method for the encoder.

FYI: In this state, the PR introduce backward incompatible changes. I am willing to discuss it further to find a solution that would fit both our interests. Of course.

regards,